### PR TITLE
Fixes issues related to auto-reconnect functionality.

### DIFF
--- a/src/ciSpaceBrew.h
+++ b/src/ciSpaceBrew.h
@@ -274,6 +274,8 @@ namespace cinder {
             
             
         protected:
+			
+			void initialize();
             
             //This is the connection to your Cinder App's Update Method
             signals::connection updateConnection;
@@ -291,7 +293,7 @@ namespace cinder {
             int lastTimeTriedConnect;
             int reconnectInterval;
             
-            WebSocketClient client;
+            WebSocketClient* client;
             
         };
             


### PR DESCRIPTION
There were a few issues related to auto-reconnect functionality:
- The method: Connection::setReconnectRate( int reconnectMillis ) expects a milliseconds value but Connection::update() internally expects seconds.
- Within Connection::update(), reconnection is attempted through the call to connect( host, config ). This version of the connect() method appends the "ws://" prefix and port number suffix to an already formatted host string.
- Once the two above issues are resolved, reconnection behavior through the WebSocketClient object still does not work as expected. I found that the simplest way to fix the problem was to dump the WebSocketClient and reinitialize it. In my testing, this allows proper reconnection to the spacebrew server.
